### PR TITLE
Add French SomaFM locale

### DIFF
--- a/locale/fr-fr/radio.voc
+++ b/locale/fr-fr/radio.voc
@@ -1,0 +1,3 @@
+radio
+radio internet
+web radio

--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -1,5 +1,5 @@
 {
-  "name": "Skill SomaFM",
+  "name": "SomaFM",
   "examples": [
     "Joue SomaFM",
     "Joue Secret Agent",

--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -1,0 +1,8 @@
+{
+  "name": "Skill SomaFM",
+  "examples": [
+    "Joue SomaFM",
+    "Joue Secret Agent",
+    "Joue Metal Detector"
+  ]
+}

--- a/locale/fr-fr/somafm.voc
+++ b/locale/fr-fr/somafm.voc
@@ -1,0 +1,2 @@
+soma fm
+somafm

--- a/locale/fr-fr/somafm_skill.voc
+++ b/locale/fr-fr/somafm_skill.voc
@@ -1,0 +1,2 @@
+(soma fm|somafm)
+(soma fm|somafm) skill

--- a/locale/fr-fr/somafm_skill.voc
+++ b/locale/fr-fr/somafm_skill.voc
@@ -1,2 +1,2 @@
 (soma fm|somafm)
-(soma fm|somafm) skill
+(soma fm|somafm) compétence

--- a/locale/fr-fr/somafm_skill.voc
+++ b/locale/fr-fr/somafm_skill.voc
@@ -1,2 +1,2 @@
 (soma fm|somafm)
-(soma fm|somafm) compétence
+radio (soma fm|somafm)


### PR DESCRIPTION
## Summary
- add the missing French SomaFM vocabulary files and localized skill metadata
- keep the trigger terms aligned with the existing English command surface

## Validation
- verified fr-fr file coverage against locale/en-us
- validated locale/fr-fr/skill.json parses as JSON